### PR TITLE
Plug shibuqam and an other auth

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,10 @@ build:
 	#nitserial src/app.nit -o src/app_serial.nit
 	nitc src/app.nit -m src/app_serial.nit -o bin/app
 
+debug:
+	mkdir -p bin
+	nitc src/app_debug.nit -m src/app_serial.nit -o bin/app
+
 populate:
 	mkdir -p bin
 	nitserial src/db_loader.nit -o src/db_loader_serial.nit

--- a/src/api/api_auth_github.nit
+++ b/src/api/api_auth_github.nit
@@ -1,0 +1,69 @@
+# Copyright 2016 Alexandre Terrasa <alexandre@moz-code.org>.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+module api_auth_github
+
+import api_auth
+import popcorn::pop_auth
+
+redef class AuthRouter
+	redef init do
+		use("/login", new GithubLogin(config.gh_client_id))
+		use("/oauth", new MissionsGithubOAuthCallBack(config))
+		use("/logout", new GithubLogout)
+		super
+	end
+end
+
+class MissionsGithubOAuthCallBack
+	super GithubOAuthCallBack
+	super APIHandler
+
+	autoinit config
+
+	init do
+		client_id = config.gh_client_id
+		client_secret = config.gh_client_secret
+	end
+
+	redef fun get(req, res) do
+		super
+		var session = req.session
+		if session == null then return
+		var user = session.user
+		if user == null then return
+		var id = user.login
+		var player = config.players.find_by_id(id)
+		if player == null then
+			player = new Player(id)
+			player.name = user.login
+			player.avatar_url = user.avatar_url
+			player.add_achievement(config, new FirstLoginAchievement(player))
+			config.players.save player
+		end
+		session.player = player
+		res.redirect "/player"
+	end
+
+end
+
+redef class GithubLogout
+	redef fun get(req, res) do
+		var session = req.session
+		if session == null then return
+		session.user = null
+		session.player = null
+		res.redirect "/"
+	end
+end

--- a/src/api/api_auth_rand.nit
+++ b/src/api/api_auth_rand.nit
@@ -1,0 +1,46 @@
+# Copyright 2016 Alexandre Terrasa <alexandre@moz-code.org>.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+module api_auth_rand
+
+import api_auth
+
+redef class AuthRouter
+	redef init do
+		use("/loginas", new RandLogin(config))
+	end
+end
+
+# Authoritatively set a player (without authentication)
+#
+# the `id` GET argument is the player id.
+# If no such a player exists nothing is done.
+# example: http://localhost:3000/auth/loginas?id=Morriar
+class RandLogin
+	super APIHandler
+
+	autoinit config
+
+	redef fun get(req, res) do
+		super
+		var session = req.session
+		if session == null then return
+		var id = req.get_args.get_or_null("id")
+		if id == null then return
+		var player = config.players.find_by_id(id)
+		if player == null then return
+		session.player = player
+		res.redirect "/player"
+	end
+end

--- a/src/api/api_auth_shibuqam.nit
+++ b/src/api/api_auth_shibuqam.nit
@@ -1,0 +1,81 @@
+# Copyright 2016 Alexandre Terrasa <alexandre@moz-code.org>.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+module api_auth_shibuqam
+
+import api_auth
+
+redef class AuthRouter
+	redef init do
+		use("/shiblogin", new ShibLogin(config))
+		use("/shiblogin/callback", new ShibCallback(config))
+	end
+end
+
+redef class Session
+	# Temporary secret used to avoid cross-site request forgery attacks
+	var shib_secret: nullable String = null
+end
+
+class ShibLogin
+	super APIHandler
+	autoinit config
+
+	redef fun get(req, res) do
+		var session = req.session
+		if session == null then return
+		var secret = generate_token
+		session.shib_secret = secret
+		var redir = config.app_root_url + req.url + "/callback"
+		res.redirect "https://info.uqam.ca/oauth?redir={redir.to_percent_encoding}&state={secret.to_percent_encoding}"
+	end
+end
+
+class ShibCallback
+	super APIHandler
+
+	autoinit config
+
+	redef fun get(req, res) do
+		var session = req.session
+		if session == null then return
+		var secret = session.shib_secret
+		if secret == null then return
+		session.shib_secret = null
+
+		var state = req.string_arg("state")
+		if state == null then return
+		state = state.from_percent_encoding
+		if state != secret then return
+
+		var id = req.string_arg("id")
+		if id == null then return
+		id = id.from_percent_encoding
+
+		var player = config.players.find_by_id(id)
+		if player == null then
+			player = new Player(id)
+			var name = req.string_arg("name")
+			if name != null then name = name.from_percent_encoding
+			player.name = name
+			var avatar = req.string_arg("avatar")
+			if avatar != null then avatar = avatar.from_percent_encoding
+			player.avatar_url = avatar
+			player.add_achievement(config, new FirstLoginAchievement(player))
+			config.players.save player
+		end
+		session.player = player
+		res.redirect "/player"
+	end
+end

--- a/src/app.nit
+++ b/src/app.nit
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import api
+import api_auth_github
 
 var opts = new AppOptions.from_args(args)
 var config = new AppConfig.from_options(opts)

--- a/src/app_debug.nit
+++ b/src/app_debug.nit
@@ -1,0 +1,3 @@
+import app
+import api_auth_shibuqam
+import api_auth_rand

--- a/src/config.nit
+++ b/src/config.nit
@@ -24,4 +24,14 @@ redef class AppConfig
 
 	# Github client secret used for Github OAuth login.
 	var gh_client_secret: String is lazy do return value_or_default("github.client.secret", "")
+
+	# Site root url to use for some redirect
+	# Useful if behind some reverse proxy
+	var app_root_url: String is lazy do
+		var host = app_host
+		var port = app_port
+		var url = "http://{host}"
+		if port != 80 then url += ":{port}"
+		return value_or_default("app.root_url", url)
+	end
 end


### PR DESCRIPTION
This detach github a lot more and allow to plug more authentications schema.
A shibuqamauth and a random auth are provided.

I do not know hot to handle the various auth method from a UI point of view.
Currently, I just hijacked the `AuthRouter` to add specific login subroutes.

http://localhost:3000/auth/login is still the Github login
http://localhost:3000/auth/shiblogin is the shibuqam login
http://localhost:3000/auth/loginas?id=Morriar is the random login
