### PR TITLE
Submissions and stars

### DIFF
--- a/src/model/loader.nit
+++ b/src/model/loader.nit
@@ -58,6 +58,17 @@ redef class Track
 				m.parents.add r
 			end
 
+			var tg = ini["star.time_goal"]
+			if tg != null then
+				var star = new TimeStar("Instruction CPU", 10, tg.to_i)
+				m.add_star star
+			end
+			var sg = ini["star.size_goal"]
+			if sg != null then
+				var star = new SizeStar("Taille du code machine", 10, sg.to_i)
+				m.add_star star
+			end
+
 			# Load tests, if any.
 			# This assume the Oto test file format:
 			# * Testcases start with the line `===`

--- a/src/model/missions.nit
+++ b/src/model/missions.nit
@@ -90,3 +90,22 @@ class MissionStar
 	# The reward (in points) accorded when this star is unlocked
 	var reward: Int
 end
+
+# For stars that asks the player to minimize a quantity
+class ScoreStar
+	super MissionStar
+	serialize
+
+	# The value to earn the star
+	var goal: Int
+end
+
+class SizeStar
+	super ScoreStar
+	serialize
+end
+
+class TimeStar
+	super ScoreStar
+	serialize
+end

--- a/src/model/status.nit
+++ b/src/model/status.nit
@@ -101,7 +101,12 @@ class MissionStatus
 	var track: nullable Track
 
 	# Unlocked stars
+	#
+	# TODO: remove and use `star_status` once JS is updated
 	var stars = new Array[MissionStar]
+
+	# The state of each star
+	var star_status = new Array[StarStatus]
 
 	# `mission` status for `player`
 	#
@@ -117,6 +122,21 @@ class MissionStatus
 	var is_locked: Bool is lazy do return status == "locked"
 	var is_open: Bool is lazy do return status == "open"
 	var is_success: Bool is lazy do return status == "success"
+end
+
+# The link between a Player and a Star
+class StarStatus
+	super Entity
+	serialize
+
+	# The associated star
+	var star: MissionStar
+
+	# Is the star granted?
+	var is_unlocked = false is writable
+
+	# The current best score (for ScoreStar)
+	var best_score: nullable Int = null is writable
 end
 
 class MissionStatusRepo

--- a/src/model/submissions.nit
+++ b/src/model/submissions.nit
@@ -19,8 +19,8 @@ module submissions
 
 import missions
 import players
-import markdown
-import poset
+private import markdown
+private import poset
 
 # The absolute path of a `file` in pep8term.
 # Aborts if not found
@@ -86,6 +86,9 @@ class Program
 	# Is null if no error.
 	var compilation_error: nullable String = null
 
+	# Number of failed test-cases
+	var test_errors: Int = 0
+
 	# Full validation of the program
 	fun check
 	do
@@ -125,17 +128,24 @@ class Program
 
 		# Execute each testcase
 		var i = 0 # test number
-		var ts = 0 # current time_score
-		var error = false # Did a test fail?
+		var time_score = 0
+		var errors = 0
 		for test in mission.testsuite do
 			var result = test.run(self, i)
 			results[test] = result
-			ts += result.time_score
-			if result.error != null then error = true
+			time_score += result.time_score
+			if result.error != null then errors += 1
 			i += 1
 		end
-		self.time_score = ts
-		if error then status = "error" else status = "success"
+		self.test_errors = errors
+		self.time_score = time_score
+		if errors != 0 then
+			status = "error"
+			return
+		end
+
+		# Succes. Update the mission status
+		status = "success"
 	end
 end
 

--- a/tests/test_pep.nit
+++ b/tests/test_pep.nit
@@ -43,10 +43,20 @@ n: .BLOCK 2
 """
 DECO 10,i
 .END
-"""] do
+""",
+"""
+DECI 0,d
+LDA 0,d
+ADDA 10,i
+STA 0,d
+DECO 0,d
+STOP
+.END
+"""
+] do
 		print "## Try source {i} ##"
 		var prog = new Program(player, mission, source)
-		prog.check
+		prog.check(config)
 		print "** {prog.status} errors={prog.test_errors}/{prog.results.length} size={prog.size_score or else "-"} time={prog.time_score or else "-"}"
 		var msg = prog.compilation_error
 		if msg != null then print "{msg}"

--- a/tests/test_pep.nit
+++ b/tests/test_pep.nit
@@ -47,7 +47,7 @@ DECO 10,i
 		print "## Try source {i} ##"
 		var prog = new Program(player, mission, source)
 		prog.check
-		print "** {prog.status} {prog.size_score or else "-"} {prog.time_score or else "-"}"
+		print "** {prog.status} errors={prog.test_errors}/{prog.results.length} size={prog.size_score or else "-"} time={prog.time_score or else "-"}"
 		var msg = prog.compilation_error
 		if msg != null then print "{msg}"
 		for tc, res in prog.results do

--- a/tracks/pep8/lab1-1/config.ini
+++ b/tracks/pep8/lab1-1/config.ini
@@ -1,1 +1,4 @@
 title=Addition simple
+[star]
+time_goal=24
+size_goal=17


### PR DESCRIPTION
Submission can unlock specific stars.
Moreover, the best core for each star (unlocked or not) is saved in the DB.

demo:

```
$ nitc tests/test_pep.nit && ./test_pep
tracks/pep8/lab1-1: got «Addition simple»; 4 tests
Mission Addition simple 4
## Try source 0 ##
John/Addition simple compile in out/1471571189_0
** error errors=0/0 size=- time=-
compilation error: 1 error was detected. No object code generated.
Error on line 2: Missing .END sentinal

## Try source 1 ##
John/Addition simple compile in out/1471571189_1
STAR unlocked Instruction CPU. 24 <= 24
STAR unlocked Taille du code machine. 17 <= 17
** success errors=0/4 size=17 time=24
## Try source 2 ##
John/Addition simple compile in out/1471571189_2
** error errors=3/4 size=3 time=8
Error: the result is not the expected one
--- test0/sav.txt   2016-08-18 21:46:29.876631810 -0400
+++ test0/output.txt    2016-08-18 21:46:29.876631810 -0400
@@ -1 +1 @@
-15
+10

Error: the result is not the expected one
--- test2/sav.txt   2016-08-18 21:46:29.884631885 -0400
+++ test2/output.txt    2016-08-18 21:46:29.884631885 -0400
@@ -1 +1 @@
-5
+10

Error: the result is not the expected one
--- test3/sav.txt   2016-08-18 21:46:29.888631924 -0400
+++ test3/output.txt    2016-08-18 21:46:29.888631924 -0400
@@ -1 +1 @@
--40
+10

## Try source 3 ##
John/Addition simple compile in out/1471571189_3
STAR new best score Taille du code machine. 15 < 17
** success errors=0/4 size=15 time=24
```

what is interesting in the demo is the `STAR unlocked` and `STAR new best score` message (only print at the moment)
