### PR TITLE
ng: display Mission locked when the mission is not unlocked

### DIFF
--- a/www/directives/player/mission.html
+++ b/www/directives/player/mission.html
@@ -1,26 +1,33 @@
 <div>
-	<h3>{{missionCtrl.missionStatus.mission.title}}</h3>
+	<div class='panel panel-danger' ng-if='missionCtrl.missionStatus.status == "locked"'>
+		<div class='panel-body'>
+			<p class='lead text-danger'>Mission locked</p>
+		</div>
+	</div>
+	<div ng-if='missionCtrl.missionStatus.status != "locked"'>
+		<h3>{{missionCtrl.missionStatus.mission.title}}</h3>
 
-	<table class='table'>
-		<tr>
-			<th>Status</th>
-			<th>
-				<span ng-if='missionCtrl.missionStatus.is_locked' class='glyphicon glyphicon-lock text-muted' />
-				<span ng-if='missionCtrl.missionStatus.is_open' class='glyphicon glyphicon-remove text-warning' />
-				<span ng-if='missionCtrl.missionStatus.is_success' class='glyphicon glyphicon-ok text-success' />
-				{{missionCtrl.missionStatus.status}}
-			</th>
-			<th>+ {{missionCtrl.missionStatus.mission.reward}} pts</th>
-		</tr>
-		<tr ng-repeat='star in missionCtrl.missionStatus.mission.stars.__items'>
-			<th ng-init='i = $index + 1' width='15%'>
-				<span class='glyphicon text-warning'
-					ng-repeat='self in [1, 2, 3]'
-					ng-class='{"glyphicon-star-empty": self > i, "glyphicon-star": self <= i}' />
-			</th>
-			<td width='15%'>+{{star.reward}}pts</td>
-			<td>{{star.title}}</td>
-		</tr>
-	</table>
-	<div ng-bind-html="missionCtrl.missionStatus.mission.desc"></div>
+		<table class='table'>
+			<tr>
+				<th>Status</th>
+				<th>
+					<span ng-if='missionCtrl.missionStatus.is_locked' class='glyphicon glyphicon-lock text-muted' />
+					<span ng-if='missionCtrl.missionStatus.is_open' class='glyphicon glyphicon-remove text-warning' />
+					<span ng-if='missionCtrl.missionStatus.is_success' class='glyphicon glyphicon-ok text-success' />
+					{{missionCtrl.missionStatus.status}}
+				</th>
+				<th>+ {{missionCtrl.missionStatus.mission.reward}} pts</th>
+			</tr>
+			<tr ng-repeat='star in missionCtrl.missionStatus.mission.stars.__items'>
+				<th ng-init='i = $index + 1' width='15%'>
+					<span class='glyphicon text-warning'
+						ng-repeat='self in [1, 2, 3]'
+						ng-class='{"glyphicon-star-empty": self > i, "glyphicon-star": self <= i}' />
+				</th>
+				<td width='15%'>+{{star.reward}}pts</td>
+				<td>{{star.title}}</td>
+			</tr>
+		</table>
+		<div ng-bind-html="missionCtrl.missionStatus.mission.desc"></div>
+	</div>
 </div>

--- a/www/views/mission.html
+++ b/www/views/mission.html
@@ -1,4 +1,8 @@
 <div class='container-fluid'>
-	<mission ng-if='!playerId' mission-id='missionId' />
+	<div class='panel panel-danger' ng-if='!playerId'>
+		<div class='panel-body'>
+			<p class='lead text-danger'>Mission locked</p>
+		</div>
+	</div>
 	<player-mission ng-if='playerId' player-id='playerId' mission-id='missionId' />
 </div>


### PR DESCRIPTION
Display `Mission locked` when the player tries to display the page of a locked mission.
Also display `Mission locked` on all mission pages when the player is not logged.

Please note that since we haven't decided yet of the frontend for not logged user and what to display about tracks and missions, I let the API as this. This means that a player can access the mission data through the API.

I'm waiting for a decision about what are the public/private data of the track/mission before changing the API.

Fixes #29

Signed-off-by: Alexandre Terrasa alexandre@moz-code.org
