### PR TITLE
auth: invert default between shibuqam and github auth

### DIFF
--- a/src/app.nit
+++ b/src/app.nit
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import api
-import api_auth_github
+import api_auth_shibuqam
 
 var opts = new AppOptions.from_args(args)
 var config = new AppConfig.from_options(opts)

--- a/src/app_debug.nit
+++ b/src/app_debug.nit
@@ -1,3 +1,3 @@
 import app
-import api_auth_shibuqam
+import api_auth_github
 import api_auth_rand


### PR DESCRIPTION
rationale: github need a prior configuration, shibuqam works out of the box

Signed-off-by: Jean Privat jean@pryen.org
