### PR TITLE
add missing `lazy` in attributes of `AppConfig`

### DIFF
--- a/src/model/achievements.nit
+++ b/src/model/achievements.nit
@@ -17,7 +17,7 @@ module achievements
 import model::notifications
 
 redef class AppConfig
-	var achievements = new AchievementRepo(db.collection("achievements"))
+	var achievements = new AchievementRepo(db.collection("achievements")) is lazy
 end
 
 # Achievement representation

--- a/src/model/friends.nit
+++ b/src/model/friends.nit
@@ -18,7 +18,7 @@ import model::notifications
 import model::achievements
 
 redef class AppConfig
-	var friend_requests = new FriendRequestRepo(db.collection("friend_requests"))
+	var friend_requests = new FriendRequestRepo(db.collection("friend_requests")) is lazy
 end
 
 redef class Player


### PR DESCRIPTION
AppConfig connects to the database according to the configuration (.ini)
and options. Both are processed in its constructor. E.g. `--db-host` and
`db.host`.
The `db` attribute is made lazy so that it will be evaluated after the
processing of options and after the loading of the .ini file.

Unfortunately, if other attributes use `db` in their initial value, they
will force the early evaluation of `db` that will use the default
configuration values to connect to the database.

When the options and the configuration file will be processes, it will be
too late since the `db` were already open and the handler stored in the
`db` attribute.

This seems to be an anti-pattern since `lazy` does not always mean `late`
and an early evaluation can be forced and can cause an unexpected chain
of early evaluation.

Signed-off-by: Jean Privat jean@pryen.org
