### PR TITLE
add a specific reward for solving a mission (without stars)

### DIFF
--- a/src/model/loader.nit
+++ b/src/model/loader.nit
@@ -103,6 +103,11 @@ redef class Track
 				m.parents.add r
 			end
 
+			var r = ini["reward"]
+			if r != null then
+				m.solve_reward = r.to_i
+			end
+
 			var tg = ini["star.time_goal"]
 			if tg != null then
 				var star = new TimeStar("Instruction CPU", 10, tg.to_i)

--- a/src/model/missions.nit
+++ b/src/model/missions.nit
@@ -37,10 +37,14 @@ class Mission
 	var parents = new Array[String]
 	var stars = new Array[MissionStar]
 
+	# Number of points to solve the mission (excluding stars)
+	var solve_reward: Int = 1 is writable
+
 	fun add_star(star: MissionStar) do stars.add star
 
+	# Total number of points for the mission (including stars)
 	var reward: Int is lazy do
-		var r = 0
+		var r = solve_reward
 		for star in stars do r += star.reward
 		return r
 	end

--- a/src/model/stats.nit
+++ b/src/model/stats.nit
@@ -40,6 +40,9 @@ redef class Player
 			stats.stars_count += track_status.stars_count
 			stats.stars_unlocked += track_status.stars_unlocked
 			for mission_status in track_status.missions do
+				if mission_status.is_success then
+					stats.score += mission_status.mission.solve_reward
+				end
 				for star in mission_status.stars do
 					stats.score += star.reward
 				end

--- a/tracks/pep8/lab1-1/config.ini
+++ b/tracks/pep8/lab1-1/config.ini
@@ -1,4 +1,5 @@
 title=Addition simple
+reward=10
 [star]
 time_goal=24
 size_goal=17


### PR DESCRIPTION
@ppepos proposes that stars are extra and that a reward is given when a mission is solved.

This PR need an improved UI on the mission page as the basic reward is not displayed.
