### PR TITLE
Fix broken submissions

### DIFF
--- a/src/api/api_missions.nit
+++ b/src/api/api_missions.nit
@@ -47,17 +47,17 @@ class APIMission
 		var post = req.body
 
 		var deserializer = new JsonDeserializer(post)
-		var submission = new Submission.from_deserializer(deserializer)
+		var submission_form = new SubmissionForm.from_deserializer(deserializer)
 		if not deserializer.errors.is_empty then
 			res.error 400
 			print "Error deserializing submitted mission: {post}"
 			return
 		end
-		var runner = config.engine_map[submission.engine]
-		var program = new Program(player, mission, submission.source)
-		runner.run(program, config)
+		var runner = config.engine_map[submission_form.engine]
+		var submission = new Submission(player, mission, submission_form.source)
+		runner.run(submission, config)
 
-		res.json program
+		res.json submission
 	end
 
 	redef fun get(req, res) do

--- a/src/model/engines/engine_base.nit
+++ b/src/model/engines/engine_base.nit
@@ -20,38 +20,38 @@ class Engine
 	# Which language is supported by the engine?
 	fun language: String is abstract
 
-	# Compile and run the tests for `program`
-	fun run(program: Program, config: AppConfig) do
-		program.status = "pending"
-		var runnable = compile(program)
-		program.compilation_failed = not runnable
+	# Compile and run the tests for `submission`
+	fun run(submission: Submission, config: AppConfig) do
+		submission.status = "pending"
+		var runnable = compile(submission)
+		submission.compilation_failed = not runnable
 		if not runnable then
-			program.status = "error"
-			program.update_status(config)
+			submission.status = "error"
+			submission.update_status(config)
 			return
 		end
-		var tests = program.mission.testsuite
+		var tests = submission.mission.testsuite
 		var errors = 0
 		var time = 0
 		for i in tests do
-			var res = run_test(program, i)
+			var res = run_test(submission, i)
 			time += res.time_score
-			program.results[i] = res
+			submission.results[i] = res
 			if res.error != null then errors += 1
 		end
 		if errors != 0 then
-			program.status = "error"
+			submission.status = "error"
 		else
-			program.status = "success"
+			submission.status = "success"
 		end
-		program.time_score = time
-		program.test_errors = errors
-		program.update_status(config)
+		submission.time_score = time
+		submission.test_errors = errors
+		submission.update_status(config)
 	end
 
-	# Compile `program` and check for errors and warnings
-	fun compile(program: Program): Bool is abstract
+	# Compile `submission` and check for errors and warnings
+	fun compile(submission: Submission): Bool is abstract
 
-	# Run `test` for `program`
-	fun run_test(program: Program, test: TestCase): TestResult is abstract
+	# Run `test` for `submission`
+	fun run_test(submission: Submission, test: TestCase): TestResult is abstract
 end

--- a/src/model/submissions.nit
+++ b/src/model/submissions.nit
@@ -25,7 +25,7 @@ private import poset
 # can be saved server-side so that the played can retrieve them.
 #
 # Other can be discarded (or archived for data analysis and/or the wall of shame)
-class Program
+class Submission
 	super Event
 	serialize
 
@@ -96,8 +96,8 @@ class Program
 	redef fun to_json do return serialize_to_json
 end
 
-# This model provides easy deserialization of posted submissions
-class Submission
+# This model provides easy deserialization of posted submission forms
+class SubmissionForm
 	serialize
 
 	# Source code to be run
@@ -109,14 +109,14 @@ class Submission
 end
 
 redef class MissionStar
-	# Check if the star is unlocked for the `program`
+	# Check if the star is unlocked for the `submission`
 	# Also update `status`
-	fun check(program: Program, status: MissionStatus): Bool do return false
+	fun check(submission: Submission, status: MissionStatus): Bool do return false
 end
 
 redef class ScoreStar
-	redef fun check(program, status) do
-		var score = self.score(program)
+	redef fun check(submission, status) do
+		var score = self.score(submission)
 		if score == null then return false
 
 		# Search or create the corresponding StarStatus
@@ -150,19 +150,19 @@ redef class ScoreStar
 		return false
 	end
 
-	# The specific score in program associated to `self`
-	fun score(program: Program): nullable Int is abstract
+	# The specific score in submission associated to `self`
+	fun score(submission: Submission): nullable Int is abstract
 end
 
 redef class TimeStar
-	redef fun score(program) do return program.time_score
+	redef fun score(submission) do return submission.time_score
 end
 
 redef class SizeStar
-	redef fun score(program) do return program.size_score
+	redef fun score(submission) do return submission.size_score
 end
 
-# A specific execution of a test case by a program
+# A specific execution of a test case by a submission
 class TestResult
 	super Entity
 	serialize
@@ -170,10 +170,10 @@ class TestResult
 	# The test case considered
 	var testcase: TestCase
 
-	# The program considered
-	var program: Program
+	# The submission considered
+	var submission: Submission
 
-	# The output of the `program` when feed by `testcase.provided_input`.
+	# The output of the `submission` when feed by `testcase.provided_input`.
 	var produced_output: nullable String = null is writable
 
 	# Error message

--- a/src/model/submissions.nit
+++ b/src/model/submissions.nit
@@ -26,7 +26,7 @@ private import poset
 #
 # Other can be discarded (or archived for data analysis and/or the wall of shame)
 class Program
-	super Jsonable
+	super Event
 	serialize
 
 	# The submitter
@@ -98,7 +98,6 @@ end
 
 # This model provides easy deserialization of posted submissions
 class Submission
-	super Event
 	serialize
 
 	# Source code to be run

--- a/tests/test_pep.nit
+++ b/tests/test_pep.nit
@@ -53,13 +53,13 @@ STOP
 """
 ] do
 		print "## Try source {i} ##"
-		var prog = new Program(player, mission, source)
+		var sub = new Submission(player, mission, source)
 		var runner = config.engine_map["pep8term"]
-		runner.run(prog, config)
-		print "** {prog.status} errors={prog.test_errors}/{prog.results.length} size={prog.size_score or else "-"} time={prog.time_score}"
-		var msg = prog.compilation_messages
+		runner.run(sub, config)
+		print "** {sub.status} errors={sub.test_errors}/{sub.results.length} size={sub.size_score or else "-"} time={sub.time_score}"
+		var msg = sub.compilation_messages
 		if msg != "" then print "{msg}"
-		for tc, res in prog.results do
+		for tc, res in sub.results do
 			var msg_test = res.error
 			if msg_test != null then print "{msg_test}"
 		end


### PR DESCRIPTION
The new `Event` superclass to `Submission` was breaking the deserialization as it was expecting a timestamp field.

I attached the Event superclass to `Program` and removed it from `Submission`.

I also renamed `Program` to `Submission` and `Submission` to `SubmissionForm` hoping that these better class name will reduce further ambiguity.
