### PR TITLE
Micro events

### DIFF
--- a/tests/test_pep.nit
+++ b/tests/test_pep.nit
@@ -22,11 +22,26 @@ var player = new Player("John", "Doe")
 config.players.save player
 
 # Run some submission on the missions
-for mission in config.missions.find_all do
+var mission = config.missions.find_all.first
+do
 	print "Mission {mission} {mission.testsuite.length}"
 	var i = 0
 	for source in [
 """
+""",
+"""
+DECO 10,i
+.END
+""",
+"""
+DECI n,d
+LDA n,d
+ADDA 10,i
+STA n,d
+DECO n,d
+STOP
+n: .BLOCK 3
+.END
 """,
 """
 DECI n,d
@@ -36,10 +51,6 @@ STA n,d
 DECO n,d
 STOP
 n: .BLOCK 2
-.END
-""",
-"""
-DECO 10,i
 .END
 """,
 """


### PR DESCRIPTION
Add some micro events.

I'm not that confident with the precise model but this is a start and could be improved when specific data will be required by the UI.

In the proposal, a single submission can generate three types of additional events:
- Solve: the first solve of whole mission
- StarUnlock: the first unlock of a specific star
- NewHighScore: each time the player beat its own high-score for a star

The events not saved yet in the DB as I have issues with that. I think however that the current PR can be reviewed (and merged) as is.
