### PR TITLE
Simplify configuration for docker and docker-compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,13 +17,20 @@ WORKDIR /missions
 COPY . /missions/
 RUN make pep8term && make
 
+# Configuration at build-time
+ARG MISSION_HOST=0.0.0.0
+ARG MISSION_PORT=3000
+ARG MISSION_ROOT_URL=http://localhost:${MISSION_PORT}
+
 # Expose the web application
-EXPOSE 3000
+EXPOSE ${MISSION_PORT}
 
 # Configure to work with the mongo server from compose
 RUN echo "db.host=mongodb://mongo:27017" >> app.ini \
-# Configure to listen outsite the container
-	&& echo "app.host=0.0.0.0" >> app.ini
+# Store the ARG in the config file
+	&& echo "app.host=$MISSION_HOST" >> app.ini \
+	&& echo "app.port=$MISSION_PORT" >> app.ini \
+	&& echo "app.root_url=$MISSION_ROOT_URL" >> app.ini
 
 # Populate and run
 # TODO: stop populating

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,0 +1,16 @@
+# Run the local Mission (see Dockerfile) with a mongodb
+#
+# After run the web application is available at http://localhost:3000
+#
+# Volumes are:
+#
+# * `./db/` is the persistent mongo database.
+#   It is used (shared) by the mongo docker.
+# * `./out/` is the submission directory
+#   It is provided so the admin can manage/grep/whatever the directory.
+
+version: '2'
+services:
+        web:
+                ports:
+                        - "3000:3000"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,13 +8,16 @@
 #   It is used (shared) by the mongo docker.
 # * `./out/` is the submission directory
 #   It is provided so the admin can manage/grep/whatever the directory.
+#
+# This is the base file.
+# The default version for local testing is in `docker-compose.override.yml`
+#
+# See https://docs.docker.com/compose/extends/ for details
 
 version: '2'
 services:
         web:
                 build: .
-                ports:
-                        - "3000:3000"
                 volumes:
                         - ./out:/missions/out
                 depends_on:


### PR DESCRIPTION
port and host are now configurable at docker-build time thus specific docker-compose.yml file can use them.

Bonus point, the simple localhost deployment is unchanged, so no need to update the readme.
