### PR TITLE
app: add --auth option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,10 @@ populate:
 	bin/db_loader $(level)
 
 run:
-	bin/app
+	bin/app --auth shib
+
+run-gh:
+	bin/app --auth github
 
 check:
 	nitunit .

--- a/src/api/api.nit
+++ b/src/api/api.nit
@@ -14,11 +14,16 @@
 
 module api
 
-import api::api_auth
+import api::api_auth_github
+import api::api_auth_shibuqam
 import api::api_players
 import api::api_tracks
 import api::api_missions
 import api::api_achievements
+
+redef class AuthRouter
+	redef init do super # FIXME avoid linearization conflit
+end
 
 redef class APIRouter
 	redef init do

--- a/src/api/api_auth.nit
+++ b/src/api/api_auth.nit
@@ -16,16 +16,44 @@ module api_auth
 
 import api_base
 
+redef class AppConfig
+
+	# Authentification method used
+	#
+	# At this point can be either `github` or `shib`, see the clients modules.
+	var auth_method: String is lazy do return value_or_default("auth", default_auth_method)
+
+	# Default authentification method used
+	#
+	# Will be refined based on what auth method we implement.
+	fun default_auth_method: String is abstract
+
+	redef init from_options(opts) do
+		super
+		var auth_method = opts.opt_auth_method.value
+		if auth_method != null then self["auth"] = auth_method
+	end
+end
+
+redef class AppOptions
+
+	# Authentification to use
+	#
+	# Can be either `github` or `shib`.
+	var opt_auth_method = new OptionString("Authentification service to use. Can be `github` (default) or `shib`", "--auth")
+
+	init do
+		super
+		add_option(opt_auth_method)
+	end
+end
+
 # The common auth router
 # Specific auth method can refine the class and plug additional handler
 class AuthRouter
 	super Router
 
 	var config: AppConfig
-
-	init do
-		use("/logout", new Logout)
-	end
 end
 
 redef class Session

--- a/src/api/api_auth.nit
+++ b/src/api/api_auth.nit
@@ -54,6 +54,10 @@ class AuthRouter
 	super Router
 
 	var config: AppConfig
+
+	init do
+		use("/auth_method", new AuthMethodHandler(config))
+	end
 end
 
 redef class Session
@@ -143,6 +147,20 @@ class AuthHandler
 			return null
 		end
 		return player
+	end
+end
+
+# Return the current authentification handler used.
+#
+# Could also be used to pass the login/logout uris to the frontend.
+# But I'm too lazy.
+class AuthMethodHandler
+	super APIHandler
+
+	redef fun get(req, res) do
+		var obj = new JsonObject
+		obj["auth_method"] = config.auth_method
+		res.json obj
 	end
 end
 

--- a/src/api/api_auth_github.nit
+++ b/src/api/api_auth_github.nit
@@ -17,16 +17,22 @@ module api_auth_github
 import api_auth
 import popcorn::pop_auth
 
+redef class AppConfig
+	redef var default_auth_method = "github"
+end
+
 redef class AuthRouter
 	redef init do
-		use("/login", new MissionGithubLogin(config))
-		use("/oauth", new MissionsGithubOAuthCallBack(config))
-		use("/logout", new GithubLogout)
 		super
+		if config.auth_method == "github" then
+			use("/login", new MissionsGithubLogin(config))
+			use("/oauth", new MissionsGithubOAuthCallBack(config))
+			use("/logout", new MissionsGithubLogout)
+		end
 	end
 end
 
-class MissionGithubLogin
+class MissionsGithubLogin
 	super GithubLogin
 	super AuthLogin
 
@@ -71,15 +77,15 @@ class MissionsGithubOAuthCallBack
 		session.player = player
 		redirect_after_login(req, res)
 	end
-
 end
 
-redef class GithubLogout
+class MissionsGithubLogout
+	super Logout
+
 	redef fun get(req, res) do
 		var session = req.session
 		if session == null then return
 		session.user = null
-		session.player = null
-		res.redirect "/"
+		super
 	end
 end

--- a/src/api/api_auth_shibuqam.nit
+++ b/src/api/api_auth_shibuqam.nit
@@ -20,8 +20,12 @@ private import shibuqam
 
 redef class AuthRouter
 	redef init do
-		use("/shiblogin", new ShibLogin(config))
-		use("/shiblogin/callback", new ShibCallback(config))
+		super
+		if config.auth_method == "shib" then
+			use("/shiblogin", new ShibLogin(config))
+			use("/shiblogin/callback", new ShibCallback(config))
+			use("/logout", new Logout)
+		end
 	end
 end
 

--- a/src/api/api_auth_shibuqam.nit
+++ b/src/api/api_auth_shibuqam.nit
@@ -16,7 +16,7 @@ module api_auth_shibuqam
 
 import api_auth
 private import curl
-private import shibuqam
+private import md5
 
 redef class AuthRouter
 	redef init do
@@ -77,7 +77,7 @@ class ShibCallback
 
 		# Try to get something an user for the data
 		var deser_engine = new JsonDeserializer(data)
-		var user = new User.from_deserializer(deser_engine)
+		var user = new ShUser.from_deserializer(deser_engine)
 		if deser_engine.errors.not_empty then
 			print_error "Shibuqam OAuth garbage"
 			for e in deser_engine.errors do
@@ -120,5 +120,28 @@ class ShibCallback
 		assert response isa CurlResponseSuccess
 		var data = response.body_str
 		return data
+	end
+end
+
+# Information on a user from Shibboleth/UQAM
+class ShUser
+	serialize
+
+	# The *code permanent* (or the uid for non student)
+	var id: String
+
+	# Usually the first name
+	var given_name: String
+
+	# Usually "FamilyName, FirstName"
+	var display_name: String
+
+	# The email @courrier.uqam.ca (or @uqam.ca for non student)
+	var email: String
+
+	# The Gravatar URL (based on `email`)
+	var avatar: String is lazy do
+		var md5 = email.md5
+		return "https://www.gravatar.com/avatar/{md5}?d=retro"
 	end
 end

--- a/src/api/api_auth_shibuqam.nit
+++ b/src/api/api_auth_shibuqam.nit
@@ -22,8 +22,8 @@ redef class AuthRouter
 	redef init do
 		super
 		if config.auth_method == "shib" then
-			use("/shiblogin", new ShibLogin(config))
-			use("/shiblogin/callback", new ShibCallback(config))
+			use("/login", new ShibLogin(config))
+			use("/login/oauth", new ShibCallback(config))
 			use("/logout", new Logout)
 		end
 	end
@@ -44,7 +44,7 @@ class ShibLogin
 		if session == null then return
 		var secret = generate_token
 		session.shib_secret = secret
-		var redir = config.app_root_url + req.uri + "/callback"
+		var redir = config.app_root_url + req.uri + "/oauth"
 		var url = "https://info.uqam.ca/oauth/login"
 		res.redirect "{url}?redirect_uri={redir.to_percent_encoding}&state={secret.to_percent_encoding}"
 	end

--- a/src/app.nit
+++ b/src/app.nit
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import api
-import api_auth_shibuqam
 
 var opts = new AppOptions.from_args(args)
 var config = new AppConfig.from_options(opts)

--- a/www/directives/player/menu.html
+++ b/www/directives/player/menu.html
@@ -1,20 +1,13 @@
 <ul class='nav navbar-nav navbar-right'>
-	<li class='dropdown' ng-if='!playerMenuCtrl.player'>
-		<a class='btn btn-link dropdown-toggle' type='button' data-toggle='dropdown'>
-			Login
+	<li ng-if='!playerMenuCtrl.player && playerMenuCtrl.auth_method == "github"'>
+		<a ng-click='playerMenuCtrl.login()' href='#'>
+			<span class='octicon octicon-mark-github' /> Login with GitHub
 		</a>
-		<ul class='dropdown-menu dropdown-menu-right'>
-			<li>
-				<a ng-click='playerMenuCtrl.ghLogin()' href='#'>
-					<span class='octicon octicon-mark-github' /> Github...
-				</a>
-			</li>
-			<li>
-				<a ng-click='playerMenuCtrl.shLogin()' href='#'>
-					<span class='glyphicon glyphicon-user' /> UQÀM...
-				</a>
-			</li>
-		</ul>
+	</li>
+	<li ng-if='!playerMenuCtrl.player && playerMenuCtrl.auth_method == "shib"'>
+		<a ng-click='playerMenuCtrl.login()' href='#'>
+			<span class='glyphicon glyphicon-user' /> Login with UQÀM
+		</a>
 	</li>
 	<li class='dropdown' ng-if='playerMenuCtrl.player'>
 		<a class='btn btn-link dropdown-toggle' type='button' data-toggle='dropdown'>

--- a/www/javascripts/model.js
+++ b/www/javascripts/model.js
@@ -20,6 +20,16 @@
 	angular
 		.module('model', [])
 
+		.factory('Auth', [ '$http', function($http) {
+			return {
+				getAuthMethod: function(cb, cbErr) {
+					$http.get('/auth/auth_method')
+						.success(cb)
+						.error(cbErr);
+				}
+			}
+		}])
+
 		.factory('Players', [ '$http', function($http) {
 			return {
 				getPlayers: function(cb, cbErr) {
@@ -33,6 +43,11 @@
 						.error(cbErr);
 				},
 				getAuth: function(cb, cbErr) {
+					$http.get(apiUrl + '/player')
+						.success(cb)
+						.error(cbErr);
+				},
+				getAuthMethod: function(cb, cbErr) {
 					$http.get(apiUrl + '/player')
 						.success(cb)
 						.error(cbErr);

--- a/www/javascripts/players.js
+++ b/www/javascripts/players.js
@@ -48,25 +48,27 @@
 			};
 		}])
 
-		.directive('playerMenu', ['$rootScope', function($rootScope) {
+		.directive('playerMenu', ['Errors', 'Auth', '$rootScope', function(Errors, Auth, $rootScope) {
 			return {
 				scope: {},
 				bindToController: {
 					player: '='
 				},
 				controller: ['$location', function ($location) {
-					this.ghLogin = function() {
-						window.location.replace('/auth/login?next=' + $location.absUrl());
-					}
+					var vm = this;
 
-					this.shLogin = function() {
-						window.location.replace('/auth/shiblogin?next=' + $location.absUrl());
+					this.login = function() {
+						window.location.replace('/auth/login?next=' + $location.absUrl());
 					}
 
 					this.logout = function() {
 						$rootScope.player = null;
 						window.location.replace('/auth/logout');
 					}
+
+					Auth.getAuthMethod(function(data) {
+						vm.auth_method = data.auth_method;
+					}, Errors.handleError)
 				}],
 				controllerAs: 'playerMenuCtrl',
 				templateUrl: '/directives/player/menu.html',


### PR DESCRIPTION
This PR follows #91 and #103 in order to provide a clean login experience.
- add option `--auth`, possibles values are `github` (default) or `shib`
- add a /auth/auth_method route that return the auth method used in JSON format
- select the frontend authentification link from `/auth/auth_method`

To run with github (default):

```
make run
# or ./app
# or ./app --auth github
```

To run  with shibotruc:

```
make run-shib
# or ./app --auth shib
```

@privat we will need some changes on Jenkins :(

Closes #44 
