### PR TITLE
Run engines in a sub-script

### DIFF
--- a/share/nitcrun.sh
+++ b/share/nitcrun.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+
+# Script to compile and execute a pep8 subission.
+# Communication is done with the file system:
+#
+# INPUT
+#
+# * source.nit : the submission source code
+# * test*/input.txt : the input for each test
+#
+# OUTPUT
+#
+# * cmperr.txt : compilation error messages
+# * test*/output.txt : the produced output for each test
+# * test*/execerr.txt : execution error messages, if any (should not occur)
+# * test*/timescore.txt : the time execution according to `time`
+#
+# To avoid the submission to look at the expected results or to temper them, the script just compile and run.
+# The evaluation of the results has to be done by the caller.
+
+# Try to compile
+compile() {
+	# Try to compile
+	nitc source.nit 2> cmperr.txt
+}
+
+# Run a test of subdirectory
+runtest() {
+	t=$1
+
+	# Try to execute the program on the test input
+	time -o $t/timescore.txt ./source < $t/input.txt > $t/output.txt 2> $t/execerr.txt 
+}
+
+# Main
+compile || exit 1
+for t in test*; do runtest "$t"; done

--- a/share/peprun.sh
+++ b/share/peprun.sh
@@ -1,0 +1,64 @@
+#!/bin/sh
+
+# Script to compile and execute a pep8 subission.
+# Communication is done with the file system:
+#
+# INPUT
+#
+# * source.pep : the submission source code
+# * test*/input.txt : the input for each test
+#
+# OUTPUT
+#
+# * cmperr.txt : compilation error messages
+# * test*/output.txt : the produced output for each test
+# * test*/execerr.txt : execution error messages, if any (should not occur)
+# * test*/timescore.txt : the time execution according to pep8term
+#
+# To avoid the submission to look at the expected results or to temper them, the script just compile and run.
+# The evaluation of the results has to be done by the caller.
+
+# Try to compile
+compile() {
+	# Try to compile
+	./asem8 source.pep 2> cmperr.txt
+
+	# Compilation failed. Exit
+	test -f source.pepo || return 1
+
+	return 0
+}
+
+# Run a test of subdirectory
+runtest() {
+	t=$1
+
+	# Pep8 is interactive and need an input
+	cat > $t/canned_command <<EOF
+l
+source
+i
+f
+$t/input.txt
+o
+f
+$t/output.txt
+x
+q
+EOF
+
+	# Try to execute the program on the test input
+	./pep8 < $t/canned_command > /dev/null 2> $t/execerr.txt || return 1
+
+	# Add a mandatory EOL at EOF to simplify diffing
+	echo >> $t/output.txt
+
+	# If success, execerr.txt contains the time score in fact.
+	mv $t/execerr.txt $t/timescore.txt
+
+	return 0
+}
+
+# Main
+compile || exit 1
+for t in test*; do runtest "$t"; done

--- a/share/saferun.sh
+++ b/share/saferun.sh
@@ -1,0 +1,1 @@
+saferun_bash.sh

--- a/share/saferun_bash.sh
+++ b/share/saferun_bash.sh
@@ -1,0 +1,19 @@
+# Small script that executes in as the main user
+#
+# usage:
+#   ./saferun.sh dir command
+
+dir=$1
+cmd=$2
+
+run=$dir/run.sh
+
+echo "$cmd" > "$run"
+chmod +x "$run"
+
+if ! test -e "$run"; then
+	echo >&2 "Error. '$run' not found."
+	exit 1
+fi
+
+cd "$dir" && exec ./run.sh

--- a/src/api/api_missions.nit
+++ b/src/api/api_missions.nit
@@ -54,7 +54,7 @@ class APIMission
 			return
 		end
 		var runner = config.engine_map[submission_form.engine]
-		var submission = new Submission(player, mission, submission_form.source)
+		var submission = new Submission(player, mission, submission_form.source.decode_base64.to_s)
 		runner.run(submission, config)
 
 		res.json submission

--- a/src/model/engines/engine_base.nit
+++ b/src/model/engines/engine_base.nit
@@ -147,7 +147,7 @@ class Engine
 
 	# Prepare workspace and target file for compilation
 	fun prepare_compilation(submission: Submission): Bool do
-		var source = submission.source.decode_base64
+		var source = submission.source
 
 		var ws = make_workspace
 		if ws == null then

--- a/tests/test_nitc.nit
+++ b/tests/test_nitc.nit
@@ -31,13 +31,16 @@ for source in [
 """
 """,
 """
+echo Hello, World!
+""",
+"""
 print "hello world"
 """,
 """
 class Hello
 	fun hi: String do return "Hello, World!"
 end
-print (new Hello).hi
+print((new Hello).hi)
 """,
 """
 print "Hello, World!"
@@ -47,12 +50,15 @@ print "Hello, World!"
 	var prog = new Submission(player, mission, source)
 	var runner = config.engine_map["nitc"]
 	runner.run(prog, config)
-	print "** {prog.status} errors={prog.test_errors}/{prog.results.length} size={prog.size_score or else "-"} time={prog.time_score}"
+	print "** {prog.status} errors={prog.test_errors}/{prog.results.length} size={prog.size_score or else "-"} time={prog.time_score or else "-"}"
 	var msg = prog.compilation_messages
 	if msg != "" then print "{msg}"
-	for tc, res in prog.results do
+	for res in prog.results do
 		var msg_test = res.error
 		if msg_test != null then print "{msg_test}"
+	end
+	for e in prog.events do
+		print e
 	end
 	i += 1
 end

--- a/tracks/nit/01_hello/config.ini
+++ b/tracks/nit/01_hello/config.ini
@@ -1,1 +1,2 @@
 title=Hello, World!
+star.size_goal=22


### PR DESCRIPTION
This change the way the engine run tests to allow a future sandboxed environment.
The idea is to have a single sandboxed execution to avoid delay, the drawback is that this single execution must compile and run all the tests.

Instead of compiling and running itself, the web app:
- prepare all the files in the workspace
- run a script in the workspace (a future PR will sandbox the script)
- the script compile and run the tests
- the webapp look at the generated file in the workspace and do some diff/count/etc.
