### PR TITLE
vendors: introduce pep8 coloring for code mirror

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -22,6 +22,8 @@
 		<link href='//cdnjs.cloudflare.com/ajax/libs/diff2html/2.0.3/diff2html.min.css'
 			type='text/css' rel='stylesheet'>
 
+		<link href='/vendors/codemirror/pep8.css' rel='stylesheet'>
+
 		<link href='/stylesheets/cards.css' rel='stylesheet'>
 		<link href='/stylesheets/app.css' rel='stylesheet'>
 	</head>
@@ -71,7 +73,9 @@
 		</script>
 		<script src='https://cdnjs.cloudflare.com/ajax/libs/jquery.tipsy/1.0.3/jquery.tipsy.min.js'></script>
 		<script src='//cdnjs.cloudflare.com/ajax/libs/codemirror/5.18.2/codemirror.min.js'></script>
-		<script src='//cdnjs.cloudflare.com/ajax/libs/codemirror/5.18.2/mode/javascript/javascript.min.js'></script>
+		<script src='//cdnjs.cloudflare.com/ajax/libs/codemirror/5.18.2/addon/mode/simple.min.js'></script>
+		<script src='/vendors/codemirror/pep8.js'></script>
+
 		<script src='//cdnjs.cloudflare.com/ajax/libs/diff2html/2.0.3/diff2html.min.js'></script>
 		<script src='//cdnjs.cloudflare.com/ajax/libs/diff2html/2.0.3/diff2html-ui.min.js'></script>
 

--- a/www/javascripts/missions.js
+++ b/www/javascripts/missions.js
@@ -207,7 +207,7 @@
 			$scope.initCodeMirror = function() {
 				$ctrl.codeMirror = CodeMirror.fromTextArea(
 					document.getElementById('source'), {
-					mode:  "javascript",
+					mode:  "pep8",
 					lineNumbers: true,
 				});
 				$ctrl.codeMirror.doc.setValue($ctrl.source);

--- a/www/vendors/codemirror/pep8.css
+++ b/www/vendors/codemirror/pep8.css
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2016 Alexandre Terrasa <alexandre@moz-code.org>.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+.cm-instruction {
+	color: blue;
+	font-weight: bold;
+}
+
+.cm-directive {
+	color: blue;
+	font-style: italic;
+}
+
+.cm-comment, .cm-s-default .cm-comment {
+	color: #00af05
+}
+
+.cm-tag, .cm-s-default .cm-tag {
+	color: #D432D0
+}

--- a/www/vendors/codemirror/pep8.js
+++ b/www/vendors/codemirror/pep8.js
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2016 Alexandre Terrasa <alexandre@moz-code.org>.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+CodeMirror.defineSimpleMode("pep8", {
+	start: [
+		// Instructions
+		{regex: /(?:stop|rettr|movspa|movflga|br|brle|brlt|breq|brne|brge|brgt|brv|brc|call|nop|deci|deco|stro|chari|charo|addsp|subsp)\b/i, token: "instruction"},
+
+		// Instructions with register
+		{regex: /(?:not|neg|asl|asr|rol|ror|nop|add|sub|and|or|cp|ld|ldbyte|st|stbyte)(n|z|v|c|a|x|pp|co)\b/i, token: "instruction"},
+
+		// Instructions with numbers
+		{regex: /(?:ret)[0-9]\b/i, token: "instruction"},
+
+		// Directives
+		{regex: /(?:\.byte|\.word|\.block|\.ascii|\.addrss|\.equate|\.end|\.burn)\b/i, token: "directive"},
+
+		// Comments
+		{regex: /;.*/, token: "comment"},
+
+		// Tags
+		{regex: /^[a-z][a-z0-9_]{0,9}:/i, token: "tag"},
+	]
+});


### PR DESCRIPTION
Demo: 

![image](https://cloud.githubusercontent.com/assets/583144/18858542/c451543a-843a-11e6-8092-340c1d3dab5f.png)

Closes #120 

Signed-off-by: Alexandre Terrasa alexandre@moz-code.org
