### PR TITLE
Fix errors on trailing slashes in paths

### DIFF
--- a/www/javascripts/missions.js
+++ b/www/javascripts/missions.js
@@ -18,10 +18,15 @@
 	angular
 		.module('missions', ['ngSanitize', 'model'])
 
-		.controller('MissionHome', ['$stateParams', '$rootScope', '$scope', function($stateParams, $rootScope, $scope) {
+		.controller('MissionHome', ['$stateParams', '$state', '$rootScope', '$scope', function($stateParams, $state, $rootScope, $scope) {
 			if($rootScope.session) {
 				$scope.playerId = $rootScope.session._id;
 			}
+
+			if($stateParams.mid == "" || !!$stateParams.mid === false) {
+				$state.go("^");
+			}
+
 			$scope.missionId = $stateParams.mid;
 			$scope.mid = $scope.missionId;
 		}])

--- a/www/javascripts/tracks.js
+++ b/www/javascripts/tracks.js
@@ -18,10 +18,15 @@
 	angular
 		.module('tracks', ['ngSanitize', 'model'])
 
-		.controller('TrackHome', ['$stateParams', '$rootScope', '$scope', function($stateParams, $rootScope, $scope) {
+		.controller('TrackHome', ['$stateParams', '$state', '$rootScope', '$scope', function($stateParams, $state, $rootScope, $scope) {
 			if($rootScope.session) {
 				$scope.playerId = $rootScope.session._id;
 			}
+
+			if($stateParams.tid == "" || !!$stateParams.tid === false) {
+				$state.go("home");
+			}
+
 			$scope.trackId = $stateParams.tid;
 		}])
 


### PR DESCRIPTION
Both fixed paths now resolve to the first non-abstract parent view.

track/trackid/(nothing here) -> track/trackid
track/(nothing here) -> track list (aka homepage for now)

close #148 

Signed-off-by: Philippe Pepos Petitclerc ppeposp@gmail.com
