### PR TITLE
Work on icon coherence

### DIFF
--- a/www/directives/missions/status.html
+++ b/www/directives/missions/status.html
@@ -1,7 +1,7 @@
 <span ng-switch='missionStatus.status' class='mission-status-icon'>
-	<span ng-switch-when='open' class='glyphicon glyphicon-remove text-danger'
+	<span ng-switch-when='open' class='glyphicon glyphicon-console text-danger'
 		title='You have not accomplished this mission' />
-	<span ng-switch-when='success' class='glyphicon glyphicon-ok text-success'
+	<span ng-switch-when='success' class='glyphicon glyphicon-flag text-success'
 		title='You already have accomplished this mission' />
 	<span ng-switch-default class='glyphicon glyphicon-lock text-muted'
 		title='This mission is locked' />

--- a/www/stylesheets/app.css
+++ b/www/stylesheets/app.css
@@ -1,3 +1,7 @@
+/* Custom Text colors */
+.text-success { color: #5cb85c; }
+.text-info { color: #0955A0; }
+
 /* Body */
 
 body {

--- a/www/stylesheets/app.css
+++ b/www/stylesheets/app.css
@@ -193,8 +193,8 @@ body {
 
 .track-tree .node.open rect,
 .track-tree .edgePath.open path {
-	fill: #d9534f;
-	stroke: #d9534f;
+	fill: #0955A0;
+	stroke: #0955A0;
 }
 
 .track-tree .node.locked rect,

--- a/www/stylesheets/cards.css
+++ b/www/stylesheets/cards.css
@@ -49,6 +49,7 @@
 .bg-success { background-color: #5cb85c; }
 .bg-danger { background-color: #d9534f; }
 .bg-warning { background-color: #fbca04; }
+.bg-info { background-color: #0955a0; }
 
-.bg-open { background-color: #d9534f; }
+.bg-open { background-color: #0955a0; }
 .bg-locked { background-color: #aaaaaa; }


### PR DESCRIPTION
Open tracks are now blue instead of red (`Sir, notice me` instead of `Sir, you suck at life`)

Removed the remaining `x`s and Checkmarks when in the context of mission status. 
Now, things to do are signified by a console prompt and completed things are marked with a flag.

Also tweaked two colors because bootstrap's colorscheme for contextual texts is utterly off in our color palette. :art: 
