### PR TITLE
make: fix `app` rule name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-all: build pep8term
+all: bin/app pep8term
 
-build: build-populate
+bin/app: build-populate
 	mkdir -p bin
 	#nitserial src/app.nit -o src/app_serial.nit
 	nitc src/app.nit -m src/app_serial.nit -o bin/app

--- a/src/app.nit
+++ b/src/app.nit
@@ -15,6 +15,12 @@
 import api
 
 var config = new AppConfig
+
+var usage = new Buffer
+usage.append "Usage: app [OPTION]...\n"
+usage.append "Missions web server."
+config.tool_description = usage.write_to_string
+
 config.parse_options(args)
 
 if config.help then

--- a/src/db_loader.nit
+++ b/src/db_loader.nit
@@ -17,6 +17,12 @@ import model::loader
 import api
 
 var config = new AppConfig
+
+var usage = new Buffer
+usage.append "Usage: app [OPTION]... <json>\n"
+usage.append "Load Missions DB from JSON files."
+config.tool_description = usage.write_to_string
+
 config.parse_options(args)
 
 


### PR DESCRIPTION
Renamed the `app` rule to `bin/app`.

Also added some tools descriptions.